### PR TITLE
update navbar links to avoid line breaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
               <a class="nav-link active" aria-current="page" href="#">Home</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="#about-us">About Us</a>
+              <a class="nav-link" href="#about-us">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#organizers">Organizers</a>
@@ -63,7 +63,7 @@
               <a class="nav-link" href="https://calendar.google.com/calendar/u/1?cid=YXN0cHJvZ3JhbW1lcnNwaGlsbHlAZ21haWwuY29t">Calendar</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="#contact-us">Contact Us</a>
+              <a class="nav-link" href="#contact-us">Contact</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Removed "Us" from two nav links to avoid line breaks on each one while changing screen sizes for uniformity in navbar responsiveness. 